### PR TITLE
Fix multipart attachment issues

### DIFF
--- a/src/service/template/template.rs
+++ b/src/service/template/template.rs
@@ -170,8 +170,7 @@ impl Template {
         let mut builder = opts
             .to_builder()
             .subject(email.subject)
-            .text(email.text)
-            .html(email.html);
+            .alternative(email.html, email.text);
         for item in opts.attachments.iter() {
             builder = builder.attachment_from_file(
                 item.filepath.as_path(),


### PR DESCRIPTION
Without the use of the [`multipart/alternative`][alternative] content type some email clients (Outlook Web Access for one) show only the plain text part of the email. The HTML part, then, is received as an attachment (called `ATT00001.htm` in the case of OWA) and is not displayed.

This patch uses `EmailBuilder.alternative()` in place of separate calls to `EmailBuilder.text()` and `EmailBuilder.html()`, which ensures that the `Content-Type: multipart/alternative` header is added.

[alternative]: https://en.wikipedia.org/wiki/MIME#Alternative