### PR TITLE
build(deps): Bump handlebars from 3.5.5 to 4.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "3.5.5"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4498fc115fa7d34de968184e473529abb40eeb6be8bc5f7faba3d08c316cb3e3"
+checksum = "2060119114dd8a8bc87facce6384751af8280a7adc8e203c023c95cbb11f5663"
 dependencies = [
  "log",
  "pest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ actix-rt = "2.2.0"
 async-trait = "0.1.50"
 env_logger = "0.8.4"
 futures = "0.3.15"
-handlebars = "3.5.5"
+handlebars = "4.0.1"
 jsonwebtoken = "7.2.0"
 lazy_static = "1.4.0"
 lettre = { default-features = false, features = ["builder", "r2d2", "rustls-tls", "smtp-transport", "tokio1-rustls-tls"], version = "0.10.0-rc.3" }

--- a/src/service/template/template.rs
+++ b/src/service/template/template.rs
@@ -1,6 +1,6 @@
 use crate::error::ServerError;
 use crate::service::multipart::MultipartFile;
-use handlebars::{Handlebars, TemplateRenderError as HandlebarTemplateRenderError};
+use handlebars::{Handlebars, RenderError as HandlebarTemplateRenderError};
 use lettre::message::{Attachment, Body, Mailbox, Message, MessageBuilder, MultiPart, SinglePart};
 use mrml::mjml::MJML;
 use mrml::prelude::parse::Error as ParserError;


### PR DESCRIPTION
closes #148

Signed-off-by: Jérémie Drouet <jeremie.drouet@gmail.com>