### PR TITLE
feat(provider): create a new http provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
  "once_cell",
  "version_check 0.9.4",
 ]
@@ -38,10 +38,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+
+[[package]]
 name = "ascii"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97be891acc47ca214468e09425d02cef3af2c94d0d82081cd02061f996802f14"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
 
 [[package]]
 name = "async-trait"
@@ -205,6 +232,7 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -294,6 +322,15 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -410,6 +447,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "retain_mut",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa37046cc0f6c3cc6090fbdbf73ef0b8ef4cfcc37f6befc0020f63e8cf121e1"
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,12 +588,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
+name = "futures"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -541,10 +619,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+
+[[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -559,13 +674,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -581,6 +705,17 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check 0.9.4",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -693,6 +828,27 @@ name = "http-range-header"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
+name = "http-types"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "base64 0.13.1",
+ "futures-lite",
+ "http",
+ "infer",
+ "pin-project-lite",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_urlencoded",
+ "url 2.3.1",
+]
 
 [[package]]
 name = "httparse"
@@ -828,6 +984,12 @@ dependencies = [
  "hashbrown",
  "serde",
 ]
+
+[[package]]
+name = "infer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "instant"
@@ -1308,6 +1470,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1564,13 +1732,26 @@ dependencies = [
  "libc",
  "rand_chacha 0.1.1",
  "rand_core 0.4.2",
- "rand_hc",
+ "rand_hc 0.1.0",
  "rand_isaac",
  "rand_jitter",
  "rand_os",
  "rand_pcg",
  "rand_xorshift",
  "winapi",
+]
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
 ]
 
 [[package]]
@@ -1592,6 +1773,16 @@ checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 dependencies = [
  "autocfg 0.1.8",
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1621,11 +1812,20 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -1635,6 +1835,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1723,7 +1932,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
  "redox_syscall",
  "thiserror",
 ]
@@ -1801,6 +2010,12 @@ dependencies = [
  "webpki-roots",
  "winreg",
 ]
+
+[[package]]
+name = "retain_mut"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "ring"
@@ -1974,6 +2189,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "184c643044780f7ceb59104cef98a5a6f12cb2288a7bc701ab93a362b49fd47d"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding 2.2.0",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -2494,6 +2720,7 @@ dependencies = [
  "form_urlencoded",
  "idna 0.3.0",
  "percent-encoding 2.2.0",
+ "serde",
 ]
 
 [[package]]
@@ -2542,7 +2769,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -2564,6 +2791,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
 name = "walkdir"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2583,6 +2816,12 @@ dependencies = [
  "log 0.4.17",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -2786,6 +3025,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249dc68542861d17eae4b4e5e8fb381c2f9e8f255a84f6771d5fdf8b6c03ce3c"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.13.1",
+ "deadpool",
+ "futures",
+ "futures-timer",
+ "http-types",
+ "hyper 0.14.23",
+ "log 0.4.17",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,4 @@ lazy_static = "1.4"
 multipart = "0.18"
 tower = { version = "0.4" }
 uuid = { version = "1.2", features = ["v4"] }
+wiremock = { version = "0.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ metrics-exporter-prometheus = { version = "0.11", default-features = false, feat
   "http-listener",
 ] }
 mrml = { version = "1.2" }
+reqwest = { version = "0.11", default-features = false, features = [
+  "json",
+  "rustls-tls",
+] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 tempfile = { version = "3.3" }
@@ -38,9 +42,5 @@ utoipa-swagger-ui = { version = "3.0", features = ["axum"] }
 [dev-dependencies]
 lazy_static = "1.4"
 multipart = "0.18"
-reqwest = { version = "0.11", default-features = false, features = [
-  "json",
-  "rustls-tls",
-] }
 tower = { version = "0.4" }
 uuid = { version = "1.2", features = ["v4"] }

--- a/src/controller/templates/json.rs
+++ b/src/controller/templates/json.rs
@@ -302,7 +302,7 @@ mod tests {
         .await
         .unwrap_err();
         assert_eq!(result.code, StatusCode::BAD_REQUEST);
-        assert_eq!(result.message, "unable to find template");
+        assert_eq!(result.message, "unable to prepare template");
     }
 
     #[tokio::test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,14 @@ impl ServerError {
         }
     }
 
+    pub(crate) fn failed_dependency() -> Self {
+        Self {
+            code: StatusCode::FAILED_DEPENDENCY,
+            message: "external service failed",
+            details: None,
+        }
+    }
+
     pub(crate) fn message(mut self, message: &'static str) -> Self {
         self.message = message;
         self

--- a/src/service/provider/http.rs
+++ b/src/service/provider/http.rs
@@ -1,0 +1,189 @@
+use super::prelude::Error;
+use crate::service::template::Template;
+use axum::http::HeaderMap;
+use reqwest::Url;
+use serde::Deserialize;
+use serde_json::Value as JsonValue;
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, serde::Deserialize)]
+pub(crate) struct Configuration {
+    pub url: String,
+    pub params: BTreeMap<String, String>,
+    pub headers: BTreeMap<String, String>,
+}
+
+impl Configuration {
+    pub(crate) fn build(&self) -> TemplateProvider {
+        tracing::debug!("building template provider");
+        TemplateProvider {
+            client: reqwest::Client::new(),
+            url: self.url.clone(),
+            params: self
+                .params
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect(),
+            headers: self
+                .headers
+                .iter()
+                .map(|(name, value)| {
+                    (
+                        reqwest::header::HeaderName::from_bytes(name.as_bytes()).unwrap(),
+                        reqwest::header::HeaderValue::from_bytes(value.as_bytes()).unwrap(),
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RemoteMetadata {
+    name: String,
+    description: String,
+    #[serde(flatten)]
+    template: RemoteMetadataTemplate,
+    attributes: JsonValue,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum RemoteMetadataTemplate {
+    Embedded { content: String },
+    Remote { template: String },
+}
+
+impl RemoteMetadata {
+    async fn content(&self, provider: &TemplateProvider, name: &str) -> Result<String, Error> {
+        match &self.template {
+            RemoteMetadataTemplate::Embedded { content } => Ok(content.to_string()),
+            RemoteMetadataTemplate::Remote { template } => {
+                let res = provider.build_request(name, template).await?;
+                let status = res.status();
+                if status.is_client_error() {
+                    tracing::error!("unable to load template content: {}", status);
+                    Err(Error::internal(
+                        "http",
+                        Cow::Borrowed("error when loading template"),
+                    ))
+                } else if status.is_server_error() {
+                    tracing::error!("unable to load template content: {}", status);
+                    Err(Error::provider(
+                        "http",
+                        Cow::Borrowed("error when loading template"),
+                    ))
+                } else {
+                    res.text().await.map_err(|err| {
+                        tracing::error!("unable to load template content: {:?}", err);
+                        Error::provider("http", Cow::Borrowed("unable to load template content"))
+                    })
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TemplateProvider {
+    client: reqwest::Client,
+    url: String,
+    params: Vec<(String, String)>,
+    headers: HeaderMap,
+}
+
+impl TemplateProvider {
+    #[cfg(test)]
+    fn new(url: String) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            url,
+            params: Default::default(),
+            headers: Default::default(),
+        }
+    }
+
+    fn interpolate(&self, name: &str, filename: &str) -> String {
+        if self.url.ends_with('/') {
+            format!("{}{}/{}", self.url, name, filename)
+        } else {
+            format!("{}/{}/{}", self.url, name, filename)
+        }
+    }
+
+    fn build_url(&self, name: &str, filename: &str) -> Result<Url, Error> {
+        let base_url = self.interpolate(name, filename);
+        Url::parse_with_params(base_url.as_str(), self.params.iter()).map_err(|err| {
+            tracing::error!("unable to generate metadata url: {:?}", err);
+            Error::configuration(
+                "http",
+                Cow::Owned(format!(
+                    "unable to build url for template {name} and {filename}"
+                )),
+            )
+        })
+    }
+
+    async fn build_request(&self, name: &str, filename: &str) -> Result<reqwest::Response, Error> {
+        let url = self.build_url(name, filename)?;
+        self.client
+            .get(url)
+            .headers(self.headers.clone())
+            .send()
+            .await
+            .map_err(|err| {
+                tracing::error!("unable to request template {}: {:?}", filename, err);
+                Error::configuration("http", Cow::Borrowed("unable to request template"))
+            })
+    }
+
+    pub(super) async fn find_by_name(&self, name: &str) -> Result<Template, Error> {
+        tracing::debug!("loading template {}", name);
+        let res = self.build_request(name, "metadata.json").await?;
+        let metadata: RemoteMetadata = res.json().await.map_err(|err| {
+            tracing::error!("unable to parse template metadata: {:?}", err);
+            Error::provider("http", Cow::Borrowed("unable to parse template metadata"))
+        })?;
+        let template_content = metadata.content(self, name).await.map_err(|err| {
+            tracing::error!("unable to load template content: {:?}", err);
+            Error::provider("http", Cow::Borrowed("unable to load template content"))
+        })?;
+        Ok(Template {
+            name: metadata.name,
+            description: metadata.description,
+            content: template_content,
+            attributes: metadata.attributes,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TemplateProvider;
+
+    fn interpolate(url: &str, name: &str) -> String {
+        TemplateProvider::new(url.into()).interpolate(name, "metadata.json")
+    }
+
+    #[test]
+    fn should_interpolate_template_name() {
+        assert_eq!(
+            interpolate(
+                "https://raw.githubusercontent.com/jdrouet/catapulte/main/template/",
+                "user-login"
+            ),
+            "https://raw.githubusercontent.com/jdrouet/catapulte/main/template/user-login/metadata.json"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_github_templates() {
+        crate::try_init_logs();
+        let provider = TemplateProvider::new(
+            "https://raw.githubusercontent.com/jdrouet/catapulte/main/template/".into(),
+        );
+        let result = provider.find_by_name("user-login").await.unwrap();
+        assert!(result.content.starts_with("<mjml>"));
+    }
+}

--- a/src/service/provider/local.rs
+++ b/src/service/provider/local.rs
@@ -58,25 +58,19 @@ impl TemplateProvider {
         let metadata_file = File::open(path).map_err(|err| {
             metrics::increment_counter!("template_provider_error", "reason" => "metadata_not_found");
             tracing::debug!("template provider error: metadata not found ({:?})", err);
-            Error::Loading {
-                origin: Cow::Borrowed("opening metadata"),
-            }
+            Error::not_found("local", Cow::Borrowed("unable to open metadata"))
         })?;
         let metadata_reader = BufReader::new(metadata_file);
         let metadata: LocalMetadata = serde_json::from_reader(metadata_reader).map_err(|err| {
             metrics::increment_counter!("template_provider_error", "reason" => "metadata_invalid");
             tracing::debug!("template provider error: metadata invalid ({:?})", err);
-            Error::Loading {
-                origin: Cow::Borrowed("parsing metadata"),
-            }
+            Error::provider("local", Cow::Borrowed("unable to parse metadata"))
         })?;
         let template_path = self.root.join(name).join(metadata.template);
         let content = read_to_string(template_path).map_err(|err| {
             metrics::increment_counter!("template_provider_error", "reason" => "template_not_found");
             tracing::debug!("template provider error: template not found ({:?})", err);
-            Error::Loading {
-                origin: Cow::Borrowed("reading template"),
-            }
+            Error::provider("local", Cow::Borrowed("unable to read template"))
         })?;
         Ok(Template {
             name: metadata.name,

--- a/src/service/provider/mod.rs
+++ b/src/service/provider/mod.rs
@@ -1,3 +1,4 @@
+pub mod http;
 pub mod local;
 pub mod prelude;
 
@@ -8,6 +9,7 @@ use prelude::Error;
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub(crate) enum Configuration {
     Local(local::Configuration),
+    Http(http::Configuration),
 }
 
 impl Default for Configuration {
@@ -21,6 +23,7 @@ impl Configuration {
         tracing::debug!("building template provider");
         match self {
             Self::Local(item) => TemplateProvider::Local(item.build()),
+            Self::Http(item) => TemplateProvider::Http(item.build()),
         }
     }
 }
@@ -28,12 +31,14 @@ impl Configuration {
 #[derive(Clone, Debug)]
 pub(crate) enum TemplateProvider {
     Local(local::TemplateProvider),
+    Http(http::TemplateProvider),
 }
 
 impl TemplateProvider {
     pub async fn find_by_name(&self, name: &str) -> Result<Template, Error> {
         match self {
             Self::Local(inner) => inner.find_by_name(name).await,
+            Self::Http(inner) => inner.find_by_name(name).await,
         }
     }
 }

--- a/src/service/provider/prelude.rs
+++ b/src/service/provider/prelude.rs
@@ -3,16 +3,63 @@ use serde_json::json;
 use std::borrow::Cow;
 
 #[derive(Clone, Debug)]
-pub enum Error {
-    Loading { origin: Cow<'static, str> },
+pub struct Error {
+    provider: &'static str,
+    kind: ErrorKind,
+    message: Cow<'static, str>,
+}
+
+impl Error {
+    pub fn not_found(provider: &'static str, message: Cow<'static, str>) -> Self {
+        Self {
+            provider,
+            kind: ErrorKind::NotFound,
+            message,
+        }
+    }
+
+    pub fn configuration(provider: &'static str, message: Cow<'static, str>) -> Self {
+        Self {
+            provider,
+            kind: ErrorKind::Configuration,
+            message,
+        }
+    }
+
+    pub fn internal(provider: &'static str, message: Cow<'static, str>) -> Self {
+        Self {
+            provider,
+            kind: ErrorKind::Internal,
+            message,
+        }
+    }
+
+    pub fn provider(provider: &'static str, message: Cow<'static, str>) -> Self {
+        Self {
+            provider,
+            kind: ErrorKind::Provider,
+            message,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum ErrorKind {
+    NotFound,
+    Provider,
+    Configuration,
+    Internal,
 }
 
 impl From<Error> for ServerError {
     fn from(err: Error) -> Self {
-        match err {
-            Error::Loading { origin } => ServerError::not_found()
-                .message("unable to find template")
-                .details(json!({ "origin": origin })),
+        match err.kind {
+            ErrorKind::NotFound => ServerError::not_found(),
+            ErrorKind::Provider => ServerError::failed_dependency(),
+            ErrorKind::Configuration => ServerError::internal(),
+            ErrorKind::Internal => ServerError::internal(),
         }
+        .message("unable to prepare template")
+        .details(json!({ "provider": err.provider, "details": err.message }))
     }
 }

--- a/src/service/provider/prelude.rs
+++ b/src/service/provider/prelude.rs
@@ -4,9 +4,9 @@ use std::borrow::Cow;
 
 #[derive(Clone, Debug)]
 pub struct Error {
-    provider: &'static str,
-    kind: ErrorKind,
-    message: Cow<'static, str>,
+    pub provider: &'static str,
+    pub kind: ErrorKind,
+    pub message: Cow<'static, str>,
 }
 
 impl Error {


### PR DESCRIPTION
### Requirements
- [x] allow to fetch templates and metadata from a static server (github for example) as 2 seperate files
- [x] allow to fetch templates and metadata from a static server (github for example) as a single file
- [ ] allow to fetch templates and metadata from a dynamic server (jolimail) as a single query

Signed-off-by: Jérémie Drouet <jeremie.drouet@gmail.com>